### PR TITLE
Add constructor to JiraProject

### DIFF
--- a/src/Services/Jira/JiraProject.php
+++ b/src/Services/Jira/JiraProject.php
@@ -1,8 +1,8 @@
 <?php
 
 /*
-* Copyright (c) 2024. Encore Digital Group.
-* All Right Reserved.
+ * Copyright (c) 2024. Encore Digital Group.
+ * All Right Reserved.
 */
 
 namespace EncoreDigitalGroup\Atlassian\Services\Jira;
@@ -18,9 +18,9 @@ use EncoreDigitalGroup\Atlassian\Services\Jira\Objects\Projects\Project;
 use Illuminate\Support\Facades\Http;
 
 /**
-* @experimental
-*
-* @api
+ * @experimental
+ *
+ * @api
 */
 class JiraProject
 {

--- a/src/Services/Jira/JiraProject.php
+++ b/src/Services/Jira/JiraProject.php
@@ -3,7 +3,7 @@
 /*
 * Copyright (c) 2024. Encore Digital Group.
 * All Right Reserved.
- */
+*/
 
 namespace EncoreDigitalGroup\Atlassian\Services\Jira;
 
@@ -19,9 +19,9 @@ use Illuminate\Support\Facades\Http;
 
 /**
 * @experimental
- *
+*
 * @api
- */
+*/
 class JiraProject
 {
     public function __construct(

--- a/src/Services/Jira/JiraProject.php
+++ b/src/Services/Jira/JiraProject.php
@@ -1,8 +1,8 @@
 <?php
 
 /*
- * Copyright (c) 2024. Encore Digital Group.
- * All Right Reserved.
+* Copyright (c) 2024. Encore Digital Group.
+* All Right Reserved.
  */
 
 namespace EncoreDigitalGroup\Atlassian\Services\Jira;
@@ -18,20 +18,26 @@ use EncoreDigitalGroup\Atlassian\Services\Jira\Objects\Projects\Project;
 use Illuminate\Support\Facades\Http;
 
 /**
- * @experimental
+* @experimental
  *
- * @api
+* @api
  */
 class JiraProject
 {
-    public static function getIssues(string $projectKey, int $startAt = 0, int $maxResults = 50): IssueSearchQueryResult
-    {
-        $hostname = AtlassianHelper::getHostname();
-        $username = AtlassianHelper::getUsername();
-        $token = AtlassianHelper::getToken();
+    public function __construct(
+        public ?string $hostname = null,
+        public ?string $username = null,
+        public ?string $token = null,
+    ) {
+        $this->hostname = $hostname ?? AtlassianHelper::getHostname();
+        $this->username = $username ?? AtlassianHelper::getUsername();
+        $this->token = $token ?? AtlassianHelper::getToken();
+    }
 
-        $response = Http::withBasicAuth($username, $token)
-            ->get($hostname . '/rest/api/2/search', [
+    public function getIssues(string $projectKey, int $startAt = 0, int $maxResults = 50): IssueSearchQueryResult
+    {
+        $response = Http::withBasicAuth($this->username, $this->token)
+            ->get($this->hostname . '/rest/api/2/search', [
                 'jql' => 'project=' . $projectKey,
                 'startAt' => $startAt,
                 'maxResults' => $maxResults,
@@ -53,7 +59,7 @@ class JiraProject
         return $issueSearchQueryResult;
     }
 
-    private static function mapIssues(mixed $data): Issue
+    private function mapIssues(mixed $data): Issue
     {
         $issue = new Issue();
         $issue->expand = $data->expand;

--- a/src/Services/Jira/JiraProject.php
+++ b/src/Services/Jira/JiraProject.php
@@ -3,7 +3,7 @@
 /*
  * Copyright (c) 2024. Encore Digital Group.
  * All Right Reserved.
-*/
+ */
 
 namespace EncoreDigitalGroup\Atlassian\Services\Jira;
 

--- a/src/Services/Jira/JiraProject.php
+++ b/src/Services/Jira/JiraProject.php
@@ -21,7 +21,7 @@ use Illuminate\Support\Facades\Http;
  * @experimental
  *
  * @api
-*/
+ */
 class JiraProject
 {
     public function __construct(


### PR DESCRIPTION
This PR adds a constructor so that you can optionally pass in values into the `JiraProject` class. The purpose of this is to make it so that you can pass in auth info when you instantiate the class, rather than relying on environment variables. But each of these values is optional, so the class will fall back on the environment variables if nothing is passed in.