### PR TITLE
[Core] Narrow Composer Requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
     "require": {
         "php": "^8.3",
         "encoredigitalgroup/stdlib": "^1.6",
-        "laravel/framework": "^10|^11",
-        "phpgenesis/phpgenesis": "^0.2.29"
+        "illuminate/support": "^10|^11",
+        "phpgenesis/http": "^0.2.29"
     },
     "require-dev": {
         "larastan/larastan": "^2.9",
@@ -34,6 +34,7 @@
         "orchestra/workbench": "^9.1",
         "pestphp/pest": "^3.0",
         "phpstan/extension-installer": "^1.3",
+        "phpstan/phpdoc-parser": "^1.0",
         "rector/rector": "^1.0",
         "tightenco/duster": "^3.0",
         "tomasvotruba/cognitive-complexity": "^0.2.3"


### PR DESCRIPTION
This PR focuses the composer dependencies in the following ways:
- Remove `laravel/framework` in favor of just `illuminate/support`
- Remove `phpgenesis/phpgenesis` in favor of just `phpgensis/http`